### PR TITLE
Add HTTP routes for deployments with web UI

### DIFF
--- a/kubernetes/apps/database/pgadmin/app/helmrelease.yaml
+++ b/kubernetes/apps/database/pgadmin/app/helmrelease.yaml
@@ -49,13 +49,13 @@ spec:
         controller: pgadmin
         ports:
           http:
-            port: 80
+            port: &port 80
     route:
       app:
         hostnames: ["{{ .Release.Name }}.f9.casa"]
         parentRefs:
-          - name: internal
-            namespace: kube-system
+          - name: external
+            namespace: network
             sectionName: https
     persistence:
       config:

--- a/kubernetes/apps/default/authelia/app/helmrelease.yaml
+++ b/kubernetes/apps/default/authelia/app/helmrelease.yaml
@@ -111,7 +111,7 @@ spec:
         hostnames: ["auth.f9.casa"]
         parentRefs:
           - name: external
-            namespace: networking
+            namespace: network
             sectionName: https
         rules:
           - backendRefs:

--- a/kubernetes/apps/default/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/default/frigate/app/helmrelease.yaml
@@ -71,6 +71,18 @@ spec:
           rtsp:
             port: 8554
 
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.f9.casa"]
+        parentRefs:
+          - name: external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
+
     persistence:
       config:
         existingClaim: frigate

--- a/kubernetes/apps/default/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/garage/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: garage
+  name: &app garage
 spec:
   interval: 1h
   chartRef:
@@ -81,7 +81,18 @@ spec:
           api:
             port: 3903
           webui:
-            port: 3909
+            port: &port 3909
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.f9.casa"]
+        parentRefs:
+          - name: external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
     persistence:
       data:
         type: nfs

--- a/kubernetes/apps/default/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/default/immich/app/helmrelease.yaml
@@ -65,24 +65,16 @@ spec:
           http:
             port: &port 2283
     route:
-      frontend:
-        enabled: true
-        kind: HTTPRoute
+      app:
+        hostnames: ["photos.f9.casa"]
         parentRefs:
-          - kind: Gateway
-            name: internal
+          - name: external
             namespace: network
-            sectionName: websecure
-        hostnames:
-          - photos.f9.casa
+            sectionName: https
         rules:
           - backendRefs:
-              - name: immich-server
+              - name: *app
                 port: *port
-            matches:
-              - path:
-                  type: PathPrefix
-                  value: /
     persistence:
       matplotlib:
         type: emptyDir

--- a/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/jellyfin/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: jellyfin
+  name: &app jellyfin
 spec:
   interval: 1h
   chartRef:
@@ -72,9 +72,13 @@ spec:
       app:
         hostnames: ["{{ .Release.Name }}.f9.casa"]
         parentRefs:
-          - name: internal
-            namespace: kube-system
+          - name: external
+            namespace: network
             sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"

--- a/kubernetes/apps/default/lldap/app/helmrelease.yaml
+++ b/kubernetes/apps/default/lldap/app/helmrelease.yaml
@@ -113,7 +113,7 @@ spec:
           gethomepage.dev/icon: mdi-account-key
         parentRefs:
           - name: external
-            namespace: networking
+            namespace: network
             sectionName: https
         rules:
           - backendRefs:

--- a/kubernetes/apps/default/openwebui/app/helmrelease.yaml
+++ b/kubernetes/apps/default/openwebui/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: openwebui
+  name: &app openwebui
 spec:
   interval: 1h
   chartRef:
@@ -58,7 +58,19 @@ spec:
       app:
         ports:
           http:
-            port: 8080
+            port: &port 8080
+
+    route:
+      app:
+        hostnames: ["chat.f9.casa"]
+        parentRefs:
+          - name: external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
 
     persistence:
       config:

--- a/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/prowlarr/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: prowlarr
+  name: &app prowlarr
 spec:
   interval: 30m
   chartRef:
@@ -107,6 +107,10 @@ spec:
           - name: external
             namespace: network
             sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
 
     persistence:
       config:

--- a/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
@@ -205,7 +205,6 @@ spec:
           - backendRefs:
               - name: *app
                 port: *port
-
     configMaps:
       config:
         data:

--- a/kubernetes/apps/default/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/radarr/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: radarr
+  name: &app radarr
 spec:
   interval: 30m
   chartRef:
@@ -107,6 +107,10 @@ spec:
           - name: external
             namespace: network
             sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
 
     persistence:
       config:

--- a/kubernetes/apps/default/recommendarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/recommendarr/app/helmrelease.yaml
@@ -43,21 +43,18 @@ spec:
       app:
         ports:
           http:
-            port: 3000
-    ingress:
+            port: &port 3000
+    route:
       app:
-        className: traefik-internal
-        hosts:
-          - host: &host "recommendarr.f9.casa"
-            paths:
-              - path: /
-                service:
-                  identifier: app
-                  port: http
-        tls:
-          - hosts:
-              - *host
-            secretName: "f9-casa-tls"
+        hostnames: ["{{ .Release.Name }}.f9.casa"]
+        parentRefs:
+          - name: external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
     persistence:
       data:
         existingClaim: "{{ .Release.Name }}"

--- a/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sabnzbd/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: sabnzbd
+  name: &app sabnzbd
 spec:
   interval: 1h
   chartRef:
@@ -73,12 +73,15 @@ spec:
             port: *port
     route:
       app:
-        hostnames:
-          - "{{ .Release.Name }}.f9.casa"
+        hostnames: ["{{ .Release.Name }}.f9.casa"]
         parentRefs:
-          - name: internal
-            namespace: kube-system
+          - name: external
+            namespace: network
             sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"

--- a/kubernetes/apps/default/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sonarr/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: sonarr
+  name: &app sonarr
 spec:
   interval: 30m
   chartRef:
@@ -107,6 +107,10 @@ spec:
           - name: external
             namespace: network
             sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
 
     persistence:
       config:

--- a/kubernetes/apps/default/zigbee/app/helmrelease.yaml
+++ b/kubernetes/apps/default/zigbee/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: zigbee
+  name: &app zigbee
 spec:
   interval: 1h
   chartRef:
@@ -95,6 +95,10 @@ spec:
           - name: external
             namespace: network
             sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
 
     persistence:
       config:

--- a/kubernetes/apps/default/zipline/app/helmrelease.yaml
+++ b/kubernetes/apps/default/zipline/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: zipline
+  name: &app zipline
 spec:
   interval: 1h
   chartRef:
@@ -103,8 +103,18 @@ spec:
       app:
         ports:
           http:
-            port: 3000
-
+            port: &port 3000
+    route:
+      app:
+        hostnames: ["i.f9.casa"]
+        parentRefs:
+          - name: external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
     persistence:
       tmpfs:
         type: emptyDir

--- a/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml
@@ -3,15 +3,19 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: rook-ceph-dashboard
+  name: github-webhook
 spec:
-  hostnames: ["rook.f9.casa"]
+  hostnames: ["flux-webhook.f9.casa"]
   parentRefs:
-    - name: internal
+    - name: external
       namespace: network
       sectionName: https
   rules:
     - backendRefs:
-        - name: rook-ceph-mgr-dashboard
-          namespace: rook-ceph
-          port: 7000
+        - name: webhook-receiver
+          namespace: flux-system
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /hook/

--- a/kubernetes/apps/flux-system/flux-instance/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ingress.yaml
+  - ./httproute.yaml
   - ./prometheusrule.yaml
   - ./receiver.yaml

--- a/kubernetes/apps/game/pterodactyl-panel/app/httproute.yaml
+++ b/kubernetes/apps/game/pterodactyl-panel/app/httproute.yaml
@@ -3,15 +3,14 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: rook-ceph-dashboard
+  name: panel
 spec:
-  hostnames: ["rook.f9.casa"]
   parentRefs:
-    - name: internal
+    - name: external
       namespace: network
       sectionName: https
+  hostnames: ["gameservers.f9.casa"]
   rules:
     - backendRefs:
-        - name: rook-ceph-mgr-dashboard
-          namespace: rook-ceph
-          port: 7000
+        - name: panel
+          port: 80

--- a/kubernetes/apps/game/pterodactyl-panel/app/kustomization.yaml
+++ b/kubernetes/apps/game/pterodactyl-panel/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./headers.yaml
   - ./middleware.yaml
   - ./ingress.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/mariadb/phpmyadmin/app/httproute.yaml
+++ b/kubernetes/apps/mariadb/phpmyadmin/app/httproute.yaml
@@ -3,15 +3,14 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: rook-ceph-dashboard
+  name: phpmyadmin
 spec:
-  hostnames: ["rook.f9.casa"]
   parentRefs:
-    - name: internal
+    - name: external
       namespace: network
       sectionName: https
+  hostnames: ["phpmyadmin.f9.casa"]
   rules:
     - backendRefs:
-        - name: rook-ceph-mgr-dashboard
-          namespace: rook-ceph
-          port: 7000
+        - name: phpmyadmin
+          port: 80

--- a/kubernetes/apps/mariadb/phpmyadmin/app/kustomization.yaml
+++ b/kubernetes/apps/mariadb/phpmyadmin/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - httproute.yaml

--- a/kubernetes/apps/network/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: echo
+  name: &app echo
 spec:
   interval: 1h
   chartRef:
@@ -73,3 +73,7 @@ spec:
           - name: external
             namespace: network
             sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port

--- a/kubernetes/apps/network/envoy-gateway/gateway/internal.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gateway/internal.yaml
@@ -4,7 +4,7 @@ kind: Gateway
 metadata:
   name: internal
   annotations:
-    external-dns.alpha.kubernetes.io/target: &ip4 10.0.10.220
+  #  external-dns.alpha.kubernetes.io/target: &ip4 10.0.10.220
 spec:
   gatewayClassName: envoy
   listeners:

--- a/kubernetes/apps/network/envoy-gateway/gateway/internal.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gateway/internal.yaml
@@ -28,4 +28,4 @@ spec:
             name: f9-casa-tls
   infrastructure:
     annotations:
-      lbipam.cilium.io/ips: *ip4
+      lbipam.cilium.io/ips: 10.0.10.220

--- a/kubernetes/apps/network/envoy-gateway/gateway/securitypolicy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gateway/securitypolicy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: internal-secure
+spec:
+  extAuth:
+    failOpen: false
+    headersToExtAuth:
+      - X-Forwarded-Proto
+      - authorization
+      - proxy-authorization
+      - accept
+      - cookie
+    http:
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: authelia
+          namespace: default
+          port: 80
+      path: /api/authz/ext-authz/
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: external

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: gatus
+  name: &app gatus
 spec:
   interval: 1h
   chartRef:
@@ -83,6 +83,17 @@ spec:
         ports:
           http:
             port: *port
+    route:
+      app:
+        hostnames: ["status.f9.casa"]
+        parentRefs:
+          - name: external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
     serviceMonitor:
       app:
         endpoints:

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -255,13 +255,15 @@ spec:
       enabled: true
     route:
       main:
-        enabled: true
-        hostnames: ["{{ .Release.Name }}.f9.ac"]
+        hostnames: ["{{ .Release.Name }}.f9.casa"]
         parentRefs:
           - name: external
             namespace: network
             sectionName: https
-
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
     persistence:
       enabled: false
     testFramework:

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -260,10 +260,6 @@ spec:
           - name: external
             namespace: network
             sectionName: https
-        rules:
-          - backendRefs:
-              - name: *app
-                port: *port
     persistence:
       enabled: false
     testFramework:

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: kromgo
+  name: &app kromgo
 spec:
   interval: 1h
   chartRef:
@@ -66,12 +66,16 @@ spec:
           health:
             port: *healthPort
     route:
-      app:
+      main:
         hostnames: ["{{ .Release.Name }}.f9.casa"]
         parentRefs:
           - name: external
-            namespace: networking
+            namespace: network
             sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
     persistence:
       config-file:
         type: configMap

--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
         hostnames: ["{{ .Release.Name }}.f9.casa"]
         parentRefs:
           - name: external
-            namespace: kube-system
+            namespace: network
             sectionName: https
     persistence:
       config-file:

--- a/kubernetes/apps/webdev/debtmanager/app/httproute.yaml
+++ b/kubernetes/apps/webdev/debtmanager/app/httproute.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: debtmanager
+spec:
+  hostnames: ["debtmanager.f9.casa"]
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: debtmanager
+          port: 80
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: debtmanager-api
+spec:
+  hostnames: ["api.f9.casa"]
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: debtmanager
+          port: 81

--- a/kubernetes/apps/webdev/games-manager/backend/app/httproute.yaml
+++ b/kubernetes/apps/webdev/games-manager/backend/app/httproute.yaml
@@ -3,15 +3,14 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: rook-ceph-dashboard
+  name: games-manager-backend
 spec:
-  hostnames: ["rook.f9.casa"]
+  hostnames: ["gamesdb.f9.casa"]
   parentRefs:
     - name: internal
       namespace: network
       sectionName: https
   rules:
     - backendRefs:
-        - name: rook-ceph-mgr-dashboard
-          namespace: rook-ceph
-          port: 7000
+        - name: games-manager-backend
+          port: 8055

--- a/kubernetes/apps/webdev/games-manager/backend/app/kustomization.yaml
+++ b/kubernetes/apps/webdev/games-manager/backend/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./deployment.yaml
   - ./service.yaml
   - ./ingress.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/webdev/games-manager/frontend/app/httproute.yaml
+++ b/kubernetes/apps/webdev/games-manager/frontend/app/httproute.yaml
@@ -3,15 +3,14 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: rook-ceph-dashboard
+  name: games-manager-frontend
 spec:
-  hostnames: ["rook.f9.casa"]
+  hostnames: ["games.f9.casa"]
   parentRefs:
     - name: internal
       namespace: network
       sectionName: https
   rules:
     - backendRefs:
-        - name: rook-ceph-mgr-dashboard
-          namespace: rook-ceph
-          port: 7000
+        - name: games-manager-frontend
+          port: 80

--- a/kubernetes/apps/webdev/games-manager/frontend/app/kustomization.yaml
+++ b/kubernetes/apps/webdev/games-manager/frontend/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./deployment.yaml
   - ./service.yaml
   - ./ingress.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/webdev/overlays/app/httproute.yaml
+++ b/kubernetes/apps/webdev/overlays/app/httproute.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: overlays
+spec:
+  hostnames: ["overlays.f9.casa"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /ws
+      backendRefs:
+        - name: overlays
+          port: 80

--- a/kubernetes/apps/webdev/overlays/app/kustomization.yaml
+++ b/kubernetes/apps/webdev/overlays/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./deployment.yaml
   - ./service.yaml
   - ./ingress.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/webdev/ws-broadcast/app/httproute.yaml
+++ b/kubernetes/apps/webdev/ws-broadcast/app/httproute.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ws-broadcast
+spec:
+  hostnames:
+    - "games.f9.casa"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /ws
+      backendRefs:
+        - name: ws-broadcast
+          port: 13370

--- a/kubernetes/apps/webdev/ws-broadcast/app/kustomization.yaml
+++ b/kubernetes/apps/webdev/ws-broadcast/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./deployment.yaml
   - ./service.yaml
   - ./ingress.yaml
+  - ./httproute.yaml


### PR DESCRIPTION
Introduce HTTP routes for all deployments and Helm releases that include a web UI, enhancing routing capabilities within the Kubernetes environment.